### PR TITLE
Remove outdated scipy pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -31,7 +31,7 @@ requirements:
     - requests
     - typing-extensions
     - s3fs >=2021.06.1
-    - scipy <1.11
+    - scipy
 
 test:
   imports:


### PR DESCRIPTION
Context:

* https://github.com/single-cell-data/TileDB-SOMA/issues/1507
* https://github.com/chanzuckerberg/cellxgene-census/blob/main/api/python/cellxgene_census/pyproject.toml has no scipy pin
* https://github.com/chanzuckerberg/cellxgene-census/blob/main/tools/cellxgene_census_builder/pyproject.toml#L37 pins scipy to 1.11.4 but this feedstock is not for the builder
* We are seeing currently a TileDB-internal Conda-solve failure which we suspect is related to this